### PR TITLE
Any icalendar v2.0 or above

### DIFF
--- a/icalendar-recurrence.gemspec
+++ b/icalendar-recurrence.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'icalendar', '~> 2.0.0.beta.1'
+  spec.add_runtime_dependency 'icalendar', '~> 2.0'
   spec.add_runtime_dependency 'ice_cube', '~> 0.11.1'
 
   spec.add_development_dependency 'rake', '~> 10.2.1'


### PR DESCRIPTION
Simple update to allow for later (non-beta) versions of icalendar, such as the current 2.1.1
