### PR TITLE
Add support for more recurrence rule fields

### DIFF
--- a/lib/icalendar/recurrence/schedule.rb
+++ b/lib/icalendar/recurrence/schedule.rb
@@ -95,10 +95,14 @@ module Icalendar
         ice_cube_recurrence_rule.tap do |r|
           days = transform_byday_to_hash(rrule.by_day)
 
-          r.month_of_year(rrule.by_month) unless rrule.by_month.nil?
+          r.month_of_year(rrule.by_month.map(&:to_i)) unless rrule.by_month.nil?
+          r.day_of_year(rrule.by_year_day.map(&:to_i)) unless rrule.by_year_day.nil?
           r.day_of_month(rrule.by_month_day.map(&:to_i)) unless rrule.by_month_day.nil?
           r.day_of_week(days) if days.is_a?(Hash) and !days.empty?
           r.day(days) if days.is_a?(Array) and !days.empty?
+          r.hour_of_day(rrule.by_hour.map(&:to_i)) unless rrule.by_hour.nil?
+          r.minute_of_hour(rrule.by_minute.map(&:to_i)) unless rrule.by_minute.nil?
+          r.second_of_minute(rrule.by_second.map(&:to_i)) unless rrule.by_second.nil?
           r.until(TimeUtil.to_time(rrule.until)) if rrule.until
           r.count(rrule.count)
         end

--- a/spec/lib/schedule_spec.rb
+++ b/spec/lib/schedule_spec.rb
@@ -49,4 +49,17 @@ describe Icalendar::Recurrence::Schedule do
       expect(schedule.parse_ical_byday("MO")).to eq({day_code: "MO", position: 0})
     end
   end
+
+  describe "#convert_rrule_to_ice_cube_recurrence_rule" do
+    let(:schedule) { Schedule.new(nil) }
+    let(:ice_cube_rule) { schedule.convert_rrule_to_ice_cube_recurrence_rule(rrule) }
+
+    context "hour, minute, second, month_of_year, and day_of_year specified" do
+      let(:rrule) { Icalendar::Values::Recur.new("FREQ=DAILY;BYHOUR=1;BYMINUTE=2;BYSECOND=3;BYMONTH=4,5;BYYEARDAY=6")}
+
+      it "adds hour, minute, second, and day_of_year to ice_cube rule" do
+        expect(ice_cube_rule).to eq IceCube::Rule.daily.hour_of_day(1).minute_of_hour(2).second_of_minute(3).month_of_year(4,5).day_of_year(6)
+      end
+    end
+  end
 end

--- a/spec/lib/schedule_spec.rb
+++ b/spec/lib/schedule_spec.rb
@@ -15,6 +15,14 @@ describe Icalendar::Recurrence::Schedule do
     end
   end
 
+  describe "#convert_day_code_to_symbol" do
+    it "returns symbol given day code" do
+      day_code = "MO"
+      schedule = Schedule.new(nil)
+      expect(schedule.convert_day_code_to_symbol(day_code)).to eq :monday
+    end
+  end
+
   describe "#occurrences_between" do
     let(:example_occurrence) do
       daily_event = example_event :daily
@@ -59,6 +67,14 @@ describe Icalendar::Recurrence::Schedule do
 
       it "adds hour, minute, second, and day_of_year to ice_cube rule" do
         expect(ice_cube_rule).to eq IceCube::Rule.daily.hour_of_day(1).minute_of_hour(2).second_of_minute(3).month_of_year(4,5).day_of_year(6)
+      end
+    end
+
+    context "week_start specified" do
+      let(:rrule) { Icalendar::Values::Recur.new("FREQ=WEEKLY;WKST=TU") }
+
+      it "adds week start to ice_cube rule" do
+        expect(ice_cube_rule.week_start).to eq :tuesday
       end
     end
   end


### PR DESCRIPTION
Adds support for second, minute, hour, day_of_year, and week_start fields of iCalendar recurrence rules.

Still missing week_of_year support, but unless I'm mistaken, IceCube doesn't support that (I opened seejohnrun/ice_cube#288 to make sure)

@jnraine 