### PR TITLE
Fix scope issue on convert_duration_to_seconds

### DIFF
--- a/lib/icalendar/recurrence/schedule.rb
+++ b/lib/icalendar/recurrence/schedule.rb
@@ -82,15 +82,14 @@ module Icalendar
 
         schedule
       end
-    end
-    
-    def convert_duration_to_seconds(ical_duration)
-      return 0 unless ical_duration
+      
+      def convert_duration_to_seconds(ical_duration)
+        return 0 unless ical_duration
 
-      conversion_rates = { seconds: 1, minutes: 60, hours: 3600, days: 86400, weeks: 604800 }
-      seconds = conversion_rates.inject(0) { |sum, (unit, multiplier)| sum + ical_duration[unit] * multiplier }
-      seconds * (ical_duration.past ? -1 : 1)
+        conversion_rates = { seconds: 1, minutes: 60, hours: 3600, days: 86400, weeks: 604800 }
+        seconds = conversion_rates.inject(0) { |sum, (unit, multiplier)| sum + ical_duration[unit] * multiplier }
+        seconds * (ical_duration.past ? -1 : 1)
+      end
     end
-
   end
 end


### PR DESCRIPTION
Was having an issue with this locally, this seemed to correct it.  Tests pass but not sure if this is included in coverage.