### PR TITLE
Bump icecube to 0.14.0

### DIFF
--- a/icalendar-recurrence.gemspec
+++ b/icalendar-recurrence.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'icalendar', '~> 2.0'
-  spec.add_runtime_dependency 'ice_cube', '~> 0.13.0'
+  spec.add_runtime_dependency 'ice_cube', '~> 0.14.0'
 
   spec.add_development_dependency 'activesupport', '~> 4.0.4'
   spec.add_development_dependency 'awesome_print'


### PR DESCRIPTION
Fixes multiple recurrence rules. See https://github.com/seejohnrun/ice_cube/commit/1d184835.

This fixes calendar events that have multiple RRULE values (which I've found is quite a few; surprised this hasn't been reported).
