### PR TITLE
Allow newer versions of ice_cube to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
+sudo: false
 rvm:
-  - 2.1.0
+  - 2.4.1
+  - 2.3.4
+  - 2.1.7
   - 2.0.0
   - 1.9.3
 script: bundle exec rspec

--- a/icalendar-recurrence.gemspec
+++ b/icalendar-recurrence.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'guard-rspec', '~> 4.2.8'
   spec.add_development_dependency 'rake', '~> 10.2.1'
   spec.add_development_dependency 'rspec', '~> 2.14.1'
   spec.add_development_dependency 'timecop', '~> 0.6.3'

--- a/icalendar-recurrence.gemspec
+++ b/icalendar-recurrence.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'icalendar', '~> 2.0'
-  spec.add_runtime_dependency 'ice_cube', '~> 0.13.0'
+  spec.add_runtime_dependency 'ice_cube', '>= 0.13.0'
 
   spec.add_development_dependency 'activesupport', '~> 4.0.4'
   spec.add_development_dependency 'awesome_print'

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -2,7 +2,7 @@ module Helpers
   def example_event(ics_name)
     ics_path = File.expand_path "#{File.dirname(__FILE__)}/fixtures/#{ics_name}_event.ics"
     ics_string = File.read(ics_path)
-    calendars = Icalendar.parse(ics_string)
+    calendars = Icalendar::Calendar.parse(ics_string)
     Array(calendars).first.events.first
   end
 end


### PR DESCRIPTION
We are trying to move to a newer version of ruby, and this dependency needs to update in order to stop the errors.

```
/home/travis/build/company/project/vendor/bundle/ruby/2.4.0/gems/ice_cube-0.13.3/lib/ice_cube/validations/month_of_year.rb:7: warning: constant ::Fixnum is deprecated
```