### PR TITLE
Update Ruby versions run on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.DS_Store
 .bundle
 .config
 .yardoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.1.7
-  - 2.0.0
-  - 1.9.3
+  - 2.5
+  - 2.4
+  - 2.1
+  - 2.0
 script: bundle exec rspec


### PR DESCRIPTION
Let's run it against the latest version of Ruby and drop 1.9.3 support (it started to fail on CI and I see no reason to keep supporting it going forward).