### PR TITLE
Add event relationship to Occurrence, populate it

### DIFF
--- a/icalendar-recurrence.gemspec
+++ b/icalendar-recurrence.gemspec
@@ -1,29 +1,29 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'icalendar/recurrence/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "icalendar-recurrence"
+  spec.name          = 'icalendar-recurrence'
   spec.version       = Icalendar::Recurrence::VERSION
-  spec.authors       = ["Jordan Raine"]
-  spec.email         = ["jnraine@gmail.com"]
-  spec.summary       = %q{Provides recurrence to icalendar gem.}
-  spec.homepage      = "https://github.com/icalendar/icalendar-recurrence"
-  spec.license       = "MIT"
+  spec.authors       = ['Jordan Raine']
+  spec.email         = ['jnraine@gmail.com']
+  spec.summary       = 'Provides recurrence to icalendar gem.'
+  spec.homepage      = 'https://github.com/icalendar/icalendar-recurrence'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'icalendar', '~> 2.0'
   spec.add_runtime_dependency 'ice_cube', '~> 0.16'
 
   spec.add_development_dependency 'activesupport', '~> 4.0'
   spec.add_development_dependency 'awesome_print'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10.2'
   spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'timecop', '~> 0.6.3'

--- a/lib/icalendar/recurrence/schedule.rb
+++ b/lib/icalendar/recurrence/schedule.rb
@@ -2,7 +2,7 @@ require 'ice_cube'
 
 module Icalendar
   module Recurrence
-    class Occurrence < Struct.new(:start_time, :end_time)
+    class Occurrence < Struct.new(:start_time, :end_time, :event)
     end
 
     class Schedule
@@ -62,7 +62,7 @@ module Icalendar
         start_time ||= ice_cube_occurrence.start_time
         end_time ||= ice_cube_occurrence.end_time
 
-        Icalendar::Recurrence::Occurrence.new(start_time, end_time)
+        Icalendar::Recurrence::Occurrence.new(start_time, end_time, @event)
       end
 
       def ice_cube_schedule
@@ -82,7 +82,7 @@ module Icalendar
 
         schedule
       end
-      
+
       def convert_duration_to_seconds(ical_duration)
         return 0 unless ical_duration
 

--- a/spec/lib/schedule_spec.rb
+++ b/spec/lib/schedule_spec.rb
@@ -1,41 +1,48 @@
 require 'spec_helper'
 
 describe Icalendar::Recurrence::Schedule do
-  describe "#occurrences_between" do
+  describe '#occurrences_between' do
     let(:example_occurrence) do
       daily_event = example_event :daily
       schedule = Schedule.new(daily_event)
-      schedule.occurrences_between(Date.parse("2014-02-01"), Date.parse("2014-03-01")).first
+      schedule.occurrences_between(Date.parse('2014-02-01'), Date.parse('2014-03-01')).first
     end
 
-    it "returns object that responds to start_time and end_time" do
+    it 'returns object that responds to start_time and end_time' do
       expect(example_occurrence).to respond_to :start_time
       expect(example_occurrence).to respond_to :end_time
+      expect(example_occurrence).to respond_to :event
     end
 
-    it "returns occurrences within range, including duration spanning #start_time " do
+    it 'returns occurrences within range, including duration spanning #start_time ' do
       schedule = Schedule.new(example_event(:week_long))
-      occurrences = schedule.occurrences_between(Time.parse("2014-01-13T09:00:00-08:00"), Date.parse("2014-01-20"), spans: true)
+      occurrences = schedule.occurrences_between(Time.parse('2014-01-13T09:00:00-08:00'), Date.parse('2014-01-20'), spans: true)
 
-      expect(schedule.start_time).to eq(Time.parse("2014-01-13T08:00:00-08:00"))
+      expect(schedule.start_time).to eq(Time.parse('2014-01-13T08:00:00-08:00'))
       expect(occurrences.count).to eq(7)
     end
 
-    context "timezoned event" do
+    it 'returns object whose event method matches the origin event' do
+      # Simple test to make sure the event carried over; different __id__
+      expect(example_occurrence.event.custom_properties).to eq example_event(:daily).custom_properties
+      expect(example_occurrence.event.name).to eq example_event(:daily).name
+    end
+
+    context 'timezoned event' do
       let(:example_occurrence) do
         timezoned_event = example_event :first_saturday_of_month
         schedule = Schedule.new(timezoned_event)
-        example_occurrence = schedule.occurrences_between(Date.parse("2014-02-01"), Date.parse("2014-03-01")).first
+        example_occurrence = schedule.occurrences_between(Date.parse('2014-02-01'), Date.parse('2014-03-01')).first
       end
 
-      it "returns object that responds to #start_time and #end_time (timezoned example)" do
+      it 'returns object that responds to #start_time and #end_time (timezoned example)' do
         expect(example_occurrence).to respond_to :start_time
         expect(example_occurrence).to respond_to :end_time
       end
     end
   end
 
-  describe "#all_occurrences" do
+  describe '#all_occurrences' do
     let(:example_occurrences) do
       weekly_event = example_event :weekly_with_count
       schedule = Schedule.new(weekly_event)
@@ -44,26 +51,25 @@ describe Icalendar::Recurrence::Schedule do
 
     let(:example_occurrence) { example_occurrences.first }
 
-    it "returns object that responds to start_time and end_time" do
+    it 'returns object that responds to start_time and end_time' do
       expect(example_occurrence).to respond_to :start_time
       expect(example_occurrence).to respond_to :end_time
     end
 
-    it "returns all occurrences" do
+    it 'returns all occurrences' do
       expect(example_occurrences.count).to eq(151)
     end
   end
 
-  context "given an event without an end time" do
+  context 'given an event without an end time' do
     let(:schedule) do
       weekly_event = example_event :weekly_with_count # has 1 hour duration
       allow(weekly_event).to receive(:end).and_return(nil)
       Schedule.new(weekly_event)
     end
 
-    it "calculates end time based on start_time and duration" do
+    it 'calculates end time based on start_time and duration' do
       expect(schedule.end_time).to eq(schedule.start_time + 1.hour)
     end
   end
-
 end


### PR DESCRIPTION
The Ical parent gem tends to follow the pattern of children retaining properties to walk 'back up' the chain - occurrences break that chain. This PR addresses that.

Apologies for the formatting; I let Rubo do its thing. Had to upgrade the Bundler version though, 1.3 wasn't playing nicely. 