### PR TITLE
Make 'er quack like an Icalendar Component!

### DIFF
--- a/lib/icalendar/recurrence/schedule.rb
+++ b/lib/icalendar/recurrence/schedule.rb
@@ -2,7 +2,7 @@ require 'ice_cube'
 
 module Icalendar
   module Recurrence
-    class Occurrence < Struct.new(:start_time, :end_time)
+    class Occurrence < Struct.new(:start_time, :end_time, :parent)
     end
 
     class Schedule
@@ -62,7 +62,7 @@ module Icalendar
         start_time ||= ice_cube_occurrence.start_time
         end_time ||= ice_cube_occurrence.end_time
 
-        Icalendar::Recurrence::Occurrence.new(start_time, end_time)
+        Icalendar::Recurrence::Occurrence.new(start_time, end_time, @event)
       end
 
       def ice_cube_schedule
@@ -82,7 +82,7 @@ module Icalendar
 
         schedule
       end
-      
+
       def convert_duration_to_seconds(ical_duration)
         return 0 unless ical_duration
 

--- a/spec/lib/schedule_spec.rb
+++ b/spec/lib/schedule_spec.rb
@@ -21,6 +21,12 @@ describe Icalendar::Recurrence::Schedule do
       expect(occurrences.count).to eq(7)
     end
 
+    it 'returns object whose event method matches the origin event' do
+      # Simple test to make sure the event carried over; different __id__
+      expect(example_occurrence.event.custom_properties).to eq example_event(:daily).custom_properties
+      expect(example_occurrence.event.name).to eq example_event(:daily).name
+    end
+
     context "timezoned event" do
       let(:example_occurrence) do
         timezoned_event = example_event :first_saturday_of_month

--- a/spec/lib/schedule_spec.rb
+++ b/spec/lib/schedule_spec.rb
@@ -23,8 +23,8 @@ describe Icalendar::Recurrence::Schedule do
 
     it 'returns object whose event method matches the origin event' do
       # Simple test to make sure the event carried over; different __id__
-      expect(example_occurrence.event.custom_properties).to eq example_event(:daily).custom_properties
-      expect(example_occurrence.event.name).to eq example_event(:daily).name
+      expect(example_occurrence.parent.custom_properties).to eq example_event(:daily).custom_properties
+      expect(example_occurrence.parent.name).to eq example_event(:daily).name
     end
 
     context "timezoned event" do


### PR DESCRIPTION
In the [Icalendar gem](https://github.com/icalendar/icalendar) there is a [`Component`](https://github.com/icalendar/icalendar/blob/master/lib/icalendar/component.rb#L5) class that [many](https://github.com/icalendar/icalendar/blob/master/lib/icalendar/journal.rb#L3) [other](https://github.com/icalendar/icalendar/blob/master/lib/icalendar/timezone.rb#L5) [classes](https://github.com/icalendar/icalendar/blob/master/lib/icalendar/alarm.rb#L3) inherit from, including [`Calendar`](https://github.com/icalendar/icalendar/blob/master/lib/icalendar/calendar.rb#L3) and [`Event`](https://github.com/icalendar/icalendar/blob/master/lib/icalendar/event.rb#L3). The `Component` specifies a [`:parent`](https://github.com/icalendar/icalendar/blob/master/lib/icalendar/component.rb#L11) attribute that is available on all of its inheritors. This is useful throughout the usage of the Icalendar gem since you can pass around a single object and still have access to most of the object tree if you need it. [`Occurrence`](https://github.com/icalendar/icalendar-recurrence/blob/master/lib/icalendar/recurrence/schedule.rb#L5) does not follow that pattern, requiring that any app passing around occurrences (either as an individual or an object) must also accompany that occurrence with the associated event if it wants any context. I don't think it's necessary to go so far as to make `Occurrence` inherit from `Component`, as I want to be wary of too much overhead on an otherwise very simple class / struct, but I think `Occurrence` could at least implement the `:parent` method since that information is readily available at the time the `Occurrence`s are instantiated in `Schedule`. 

This PR adds and populates the `:parent` method on the `Occurrence` object with a very simplistic change and adds a an example to the specs to make sure that the field _is_ populated. 