### PR TITLE
Upgrade insecure dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.ruby-version
 .DS_Store
 .bundle
 .config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 sudo: false
+before_install:
+  - gem install bundler
 rvm:
+  - 2.7
+  - 2.6
   - 2.5
   - 2.4
-  - 2.1
-  - 2.0
 script: bundle exec rspec

--- a/icalendar-recurrence.gemspec
+++ b/icalendar-recurrence.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activesupport', '~> 4.0'
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake', '~> 10.2'
-  spec.add_development_dependency 'rspec', '~> 2.14'
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rspec', '~> 3.9'
   spec.add_development_dependency 'timecop', '~> 0.6.3'
   spec.add_development_dependency 'tzinfo', '~> 0.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ include Icalendar::Recurrence
 include Helpers
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'


### PR DESCRIPTION
Upgrade to rake >= 12.3.3 and bundler 2 for development to clear the security warning.