### PR TITLE
Added all_occurrences to Icalendar::Event extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ event = Array(calendars).first.events.first # retrieve the first event
 event.occurrences_between(Date.parse("2014-01-01"), Date.parse("2014-02-01")) # get all occurrence for one month
 ```
 
+### Get all occurrences
+
+To get all occurrences you can use `all_occurrences`. This only works when you have specified an ending using `until` or `count` in your RRULE.
+
 ### Working with occurrences
 
 An event occurrence is a simple struct object with `start_time` and `end_time` methods.

--- a/lib/icalendar/recurrence/event_extensions.rb
+++ b/lib/icalendar/recurrence/event_extensions.rb
@@ -17,6 +17,10 @@ module Icalendar
         schedule.occurrences_between(begin_time, closing_time, spans: spans)
       end
 
+      def all_occurrences
+        schedule.all_occurrences
+      end
+
       def schedule
         @schedule ||= Schedule.new(self)
       end

--- a/spec/lib/recurrence_spec.rb
+++ b/spec/lib/recurrence_spec.rb
@@ -188,3 +188,28 @@ describe "Event#occurrences_between" do
     end
   end
 end
+
+describe "Event#all_occurrences" do
+  let(:start_time) { event.start_time }
+
+  context "event repeating once a month for three months" do
+    let(:event) { example_event :one_day_a_month_for_three_months }
+
+    it "get all 3 occurences" do
+      occurrences = event.all_occurrences
+
+      expect(occurrences.length).to eq(3)
+    end
+  end
+
+  context "event repeating yearly" do
+    let(:event) { example_event :first_of_every_year }
+
+    it "can not get all occurences when not using count or until" do
+      expect {
+        event.all_occurrences
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+end


### PR DESCRIPTION
#7 only added all_occurrences in the internal schedule, so it was not very practical. I never ended up actually using the method until now so never realised it was useless. This PR will add all_occurrences to Icalendar::Event extensions so it has practical usage. Two tests and readme description is also added.