### PR TITLE
Don't use TZInfo to convert to UTC

### DIFF
--- a/icalendar-recurrence.gemspec
+++ b/icalendar-recurrence.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'timecop', '~> 0.6.3'
+  spec.add_development_dependency 'timecop', '~> 0.9.6'
   spec.add_development_dependency 'tzinfo', '~> 0.3'
 end

--- a/lib/icalendar/recurrence/schedule.rb
+++ b/lib/icalendar/recurrence/schedule.rb
@@ -50,13 +50,8 @@ module Icalendar
 
       def convert_ice_cube_occurrence(ice_cube_occurrence)
         if timezone
-          begin
-            tz = TZInfo::Timezone.get(timezone)
-            start_time = tz.local_to_utc(ice_cube_occurrence.start_time)
-            end_time = tz.local_to_utc(ice_cube_occurrence.end_time)
-          rescue TZInfo::InvalidTimezoneIdentifier
-            warn "Unknown TZID specified in ical event (#{timezone.inspect}), ignoring (will likely cause event to be at wrong time!)"
-          end
+          start_time = ice_cube_occurrence.start_time.utc
+          end_time = ice_cube_occurrence.end_time.utc
         end
 
         start_time ||= ice_cube_occurrence.start_time


### PR DESCRIPTION
There is no need to use `TZInfo` to convert `Time` objects to UTC, we can simply use the `utc` method on the `Time` objects themselves. In fact, using `TZInfo::Timezone.get` will throw an error if the timezone is a custom VTimezone defined in the data.